### PR TITLE
v1.0.3: Minecraft 1.21.11 support, crafting fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.questlogs</groupId>
     <artifactId>QuestLogs</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>QuestLogs</name>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         

--- a/src/main/java/com/questlogs/listeners/CraftItemListener.java
+++ b/src/main/java/com/questlogs/listeners/CraftItemListener.java
@@ -36,28 +36,57 @@ public class CraftItemListener implements Listener {
                 return;
             }
             
+            // Check if event is cancelled - don't track cancelled crafts
+            if (event.isCancelled()) {
+                return;
+            }
+            
             if (!(event.getWhoClicked() instanceof Player)) {
                 return;
             }
             
             Player player = (Player) event.getWhoClicked();
             UUID playerId = player.getUniqueId();
-            ItemStack result = event.getCurrentItem();
+            
+            // Get the recipe result to determine what was crafted (more reliable than getCurrentItem)
+            ItemStack recipeResult = null;
+            if (event.getRecipe() != null && event.getRecipe().getResult() != null) {
+                recipeResult = event.getRecipe().getResult();
+            }
+            
+            // Get the actual result item from the event (for amount calculation)
+            ItemStack actualResult = event.getCurrentItem();
+            
+            // Determine material and amount
+            Material material;
+            int craftAmount;
+            
+            if (recipeResult != null && recipeResult.getType() != Material.AIR) {
+                // Use recipe result for material type (more reliable)
+                material = recipeResult.getType();
+                
+                // Calculate craft amount
+                if (event.isShiftClick()) {
+                    // For shift-click, calculate max possible crafts based on available ingredients
+                    craftAmount = getMaxCraftAmount(event, recipeResult);
+                } else {
+                    // For normal click, use actual result amount if available, otherwise recipe amount
+                    if (actualResult != null && actualResult.getType() == material) {
+                        craftAmount = actualResult.getAmount();
+                    } else {
+                        craftAmount = recipeResult.getAmount();
+                    }
+                }
+            } else if (actualResult != null && actualResult.getType() != Material.AIR) {
+                // Fallback to actual result if recipe is not available
+                material = actualResult.getType();
+                craftAmount = actualResult.getAmount();
+            } else {
+                // No valid result found
+                return;
+            }
         
-        if (result == null || result.getType() == Material.AIR) {
-            return;
-        }
-        
-        Material material = result.getType();
-        String materialName = material.name();
-        
-        // Calculate how many items are being crafted
-        // This handles shift-clicking to craft multiple items
-        int craftAmount = result.getAmount();
-        if (event.isShiftClick()) {
-            // For shift-click, calculate max possible crafts
-            craftAmount = getMaxCraftAmount(event, result);
-        }
+            String materialName = material.name();
         
         // Track cumulative stats for ALL items crafted (ALWAYS, regardless of quests)
         plugin.getStatsManager().getPlayerStats(playerId).addItemCrafted(materialName, craftAmount);
@@ -139,18 +168,30 @@ public class CraftItemListener implements Listener {
     }
     
     private int getMaxCraftAmount(CraftItemEvent event, ItemStack result) {
-        // Calculate maximum number of items that can be crafted
-        int maxCraftable = Integer.MAX_VALUE;
+        // For shift-click, Minecraft calculates the maximum automatically
+        // The actual result amount in the event should reflect this
+        ItemStack actualResult = event.getCurrentItem();
+        if (actualResult != null && actualResult.getType() == result.getType()) {
+            return actualResult.getAmount();
+        }
         
-        // Check each ingredient in the crafting matrix
+        // Fallback: Estimate based on available ingredients
+        // This is a simplified calculation - Minecraft's actual calculation is more complex
+        int minIngredient = Integer.MAX_VALUE;
         for (ItemStack ingredient : event.getInventory().getMatrix()) {
             if (ingredient != null && ingredient.getType() != Material.AIR) {
-                maxCraftable = Math.min(maxCraftable, ingredient.getAmount());
+                minIngredient = Math.min(minIngredient, ingredient.getAmount());
             }
         }
         
-        // Multiply by the result amount (some recipes produce multiple items)
-        return maxCraftable * result.getAmount();
+        // If we couldn't find a minimum, use recipe result amount
+        if (minIngredient == Integer.MAX_VALUE) {
+            return result.getAmount();
+        }
+        
+        // Multiply by result amount (some recipes produce multiple items per craft)
+        // Note: This is an approximation - actual Minecraft calculation considers recipe requirements
+        return minIngredient * result.getAmount();
     }
     
     private boolean isQuestComplete(Player player, Quest quest) {
@@ -215,4 +256,5 @@ public class CraftItemListener implements Listener {
         return result.toString();
     }
 }
+
 

--- a/src/main/java/com/questlogs/managers/ChallengeManager.java
+++ b/src/main/java/com/questlogs/managers/ChallengeManager.java
@@ -14,7 +14,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -53,7 +52,8 @@ public class ChallengeManager {
      */
     public void loadChallenges() {
         if (!challengesFile.exists()) {
-            createDefaultConfig();
+            // Save default config from resources
+            plugin.saveResource("challenges.yml", false);
         }
         
         challengesConfig = YamlConfiguration.loadConfiguration(challengesFile);
@@ -65,171 +65,6 @@ public class ChallengeManager {
         }
         
         logger.info("Loaded " + challengePool.size() + " challenges");
-    }
-    
-    /**
-     * Create default challenges configuration
-     */
-    private void createDefaultConfig() {
-        try {
-            challengesFile.getParentFile().mkdirs();
-            challengesFile.createNewFile();
-            
-            FileConfiguration config = YamlConfiguration.loadConfiguration(challengesFile);
-            
-            // Settings
-            config.set("settings.enabled", true);
-            config.set("settings.frequency", 3600); // 1 hour (less frequent)
-            config.set("settings.duration", 300); // 5 minutes
-            config.set("settings.announce-interval", 60); // 1 minute
-            config.set("settings.broadcast-start", true);
-            config.set("settings.broadcast-end", true);
-            config.set("settings.reward-top-players", 3);
-            config.set("settings.minimum-players", 2); // Don't start if less than 2 players online
-            
-            // Easy Challenges (common resources, modest rewards)
-            createChallenge(config, "stone_sprint", "Stone Mining Sprint", 
-                "Mine the most stone!", "MINE_BLOCKS", "STONE", 300,
-                new int[]{16, 8, 4}, "IRON_INGOT",
-                new int[]{32, 16, 8}, "COAL",
-                new int[]{0, 0, 0}, null);
-            
-            createChallenge(config, "wood_chopper", "Lumberjack Challenge", 
-                "Break the most logs!", "BREAK_BLOCKS", "OAK_LOG", 300,
-                new int[]{24, 12, 6}, "IRON_INGOT",
-                new int[]{8, 4, 2}, "GOLDEN_APPLE",
-                new int[]{1, 0, 0}, "ENCHANTED_BOOK"); // Efficiency I
-            addEnchantment(config, "wood_chopper", "1st", "EFFICIENCY", 1);
-            
-            createChallenge(config, "zombie_hunter", "Zombie Hunt", 
-                "Kill the most zombies!", "KILL_MOBS", "ZOMBIE", 300,
-                new int[]{12, 6, 3}, "IRON_INGOT",
-                new int[]{4, 2, 1}, "GOLD_INGOT",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Sharpness I/II
-            addEnchantment(config, "zombie_hunter", "1st", "SHARPNESS", 2);
-            addEnchantment(config, "zombie_hunter", "2nd", "SHARPNESS", 1);
-            
-            // Medium Challenges (less common resources, better rewards)
-            createChallenge(config, "coal_rush", "Coal Rush", 
-                "Mine the most coal ore!", "MINE_BLOCKS", "COAL_ORE", 300,
-                new int[]{20, 10, 5}, "IRON_INGOT",
-                new int[]{2, 1, 0}, "DIAMOND",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Efficiency II/III
-            addEnchantment(config, "coal_rush", "1st", "EFFICIENCY", 3);
-            addEnchantment(config, "coal_rush", "2nd", "EFFICIENCY", 2);
-            
-            createChallenge(config, "skeleton_sniper", "Skeleton Sniper", 
-                "Kill the most skeletons!", "KILL_MOBS", "SKELETON", 300,
-                new int[]{16, 8, 4}, "IRON_INGOT",
-                new int[]{2, 1, 0}, "DIAMOND",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Power II/III
-            addEnchantment(config, "skeleton_sniper", "1st", "POWER", 3);
-            addEnchantment(config, "skeleton_sniper", "2nd", "POWER", 2);
-            
-            createChallenge(config, "iron_seeker", "Iron Seeker", 
-                "Mine the most iron ore!", "MINE_BLOCKS", "IRON_ORE", 300,
-                new int[]{24, 12, 6}, "IRON_INGOT",
-                new int[]{3, 1, 0}, "DIAMOND",
-                new int[]{1, 0, 0}, "ENCHANTED_BOOK"); // Unbreaking III
-            addEnchantment(config, "iron_seeker", "1st", "UNBREAKING", 3);
-            
-            // Hard Challenges (rare resources, premium rewards)
-            createChallenge(config, "diamond_dash", "Diamond Dash", 
-                "Mine the most diamond ore!", "MINE_BLOCKS", "DIAMOND_ORE", 300,
-                new int[]{5, 3, 1}, "DIAMOND",
-                new int[]{16, 8, 4}, "IRON_INGOT",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Fortune III / Silk Touch
-            addEnchantment(config, "diamond_dash", "1st", "FORTUNE", 3);
-            addEnchantment(config, "diamond_dash", "2nd", "SILK_TOUCH", 1);
-            
-            createChallenge(config, "nether_explorer", "Nether Explorer", 
-                "Explore the most blocks in the Nether!", "EXPLORE_BLOCKS", "ANY", 300,
-                new int[]{4, 2, 1}, "DIAMOND",
-                new int[]{8, 4, 2}, "GOLD_INGOT",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Protection III/IV
-            addEnchantment(config, "nether_explorer", "1st", "PROTECTION", 4);
-            addEnchantment(config, "nether_explorer", "2nd", "PROTECTION", 3);
-            
-            // Fun/Creative Challenges
-            createChallenge(config, "builder_challenge", "Speed Builder", 
-                "Place the most blocks!", "PLACE_BLOCKS", "COBBLESTONE", 300,
-                new int[]{12, 6, 3}, "IRON_INGOT",
-                new int[]{64, 32, 16}, "OAK_PLANKS",
-                new int[]{1, 1, 0}, "ENCHANTED_BOOK"); // Efficiency II/III
-            addEnchantment(config, "builder_challenge", "1st", "EFFICIENCY", 3);
-            addEnchantment(config, "builder_challenge", "2nd", "EFFICIENCY", 2);
-            
-            createChallenge(config, "crafting_master", "Crafting Master", 
-                "Craft the most items!", "CRAFT_ITEMS", "STICK", 300,
-                new int[]{16, 8, 4}, "IRON_INGOT",
-                new int[]{8, 4, 2}, "GOLD_INGOT",
-                new int[]{1, 0, 0}, "ENCHANTED_BOOK"); // Mending
-            addEnchantment(config, "crafting_master", "1st", "MENDING", 1);
-            
-            config.save(challengesFile);
-            logger.info("Created default challenges.yml");
-            
-        } catch (IOException e) {
-            logger.severe("Could not create challenges.yml!");
-            e.printStackTrace();
-        }
-    }
-    
-    /**
-     * Create a balanced challenge with scaled rewards
-     */
-    private void createChallenge(FileConfiguration config, String id, String name, 
-                                String desc, String type, String target, int duration,
-                                int[] reward1Amounts, String reward1Type,
-                                int[] reward2Amounts, String reward2Type,
-                                int[] reward3Amounts, String reward3Type) {
-        String path = "challenge-pool." + id;
-        config.set(path + ".name", name);
-        config.set(path + ".description", desc);
-        config.set(path + ".type", type);
-        config.set(path + ".target", target);
-        config.set(path + ".duration", duration);
-        
-        // 1st place rewards
-        if (reward1Amounts[0] > 0 && reward1Type != null) {
-            config.set(path + ".rewards.1st." + reward1Type, reward1Amounts[0]);
-        }
-        if (reward2Amounts[0] > 0 && reward2Type != null) {
-            config.set(path + ".rewards.1st." + reward2Type, reward2Amounts[0]);
-        }
-        if (reward3Amounts[0] > 0 && reward3Type != null) {
-            config.set(path + ".rewards.1st." + reward3Type, reward3Amounts[0]);
-        }
-        
-        // 2nd place rewards
-        if (reward1Amounts[1] > 0 && reward1Type != null) {
-            config.set(path + ".rewards.2nd." + reward1Type, reward1Amounts[1]);
-        }
-        if (reward2Amounts[1] > 0 && reward2Type != null) {
-            config.set(path + ".rewards.2nd." + reward2Type, reward2Amounts[1]);
-        }
-        if (reward3Amounts[1] > 0 && reward3Type != null) {
-            config.set(path + ".rewards.2nd." + reward3Type, reward3Amounts[1]);
-        }
-        
-        // 3rd place rewards
-        if (reward1Amounts[2] > 0 && reward1Type != null) {
-            config.set(path + ".rewards.3rd." + reward1Type, reward1Amounts[2]);
-        }
-        if (reward2Amounts[2] > 0 && reward2Type != null) {
-            config.set(path + ".rewards.3rd." + reward2Type, reward2Amounts[2]);
-        }
-        if (reward3Amounts[2] > 0 && reward3Type != null) {
-            config.set(path + ".rewards.3rd." + reward3Type, reward3Amounts[2]);
-        }
-    }
-    
-    /**
-     * Add enchantment to an enchanted book reward
-     */
-    private void addEnchantment(FileConfiguration config, String challengeId, String place, String enchantment, int level) {
-        String path = "challenge-pool." + challengeId + ".rewards." + place + ".ENCHANTED_BOOK_enchantments." + enchantment;
-        config.set(path, level);
     }
     
     /**
@@ -436,8 +271,28 @@ public class ChallengeManager {
                 return typeMatches; // Exploration doesn't need target match
         }
         
+        if (!typeMatches) {
+            return false;
+        }
+        
         // Check target matches
-        return typeMatches && (challengeTarget.equals("ANY") || challengeTarget.equals(target));
+        if (challengeTarget.equals("ANY")) {
+            return true;
+        }
+        
+        // For CRAFT_ITEMS, support multiple items (comma-separated)
+        if (challengeType == ChallengeType.CRAFT_ITEMS && challengeTarget.contains(",")) {
+            String[] allowedItems = challengeTarget.split(",");
+            for (String item : allowedItems) {
+                if (item.trim().equalsIgnoreCase(target)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        
+        // Single target match
+        return challengeTarget.equalsIgnoreCase(target);
     }
     
     /**
@@ -450,6 +305,30 @@ public class ChallengeManager {
         Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         Bukkit.broadcastMessage(ChatColor.AQUA + activeChallenge.getName());
         Bukkit.broadcastMessage(ChatColor.GRAY + activeChallenge.getDescription());
+        
+        // Show specific items for crafting challenges
+        if (activeChallenge.getType() == ChallengeType.CRAFT_ITEMS && 
+            !activeChallenge.getTarget().equals("ANY")) {
+            String target = activeChallenge.getTarget();
+            if (target.contains(",")) {
+                // Multiple items
+                String[] items = target.split(",");
+                StringBuilder itemList = new StringBuilder();
+                for (int i = 0; i < items.length; i++) {
+                    if (i > 0) itemList.append(", ");
+                    itemList.append(formatItemName(items[i].trim()));
+                }
+                Bukkit.broadcastMessage(ChatColor.YELLOW + "Tracked Items: " + ChatColor.WHITE + itemList.toString());
+            } else {
+                // Single item
+                Bukkit.broadcastMessage(ChatColor.YELLOW + "Tracked Item: " + ChatColor.WHITE + formatItemName(target));
+            }
+        } else if (activeChallenge.getType() != ChallengeType.EXPLORE_BLOCKS && 
+                   !activeChallenge.getTarget().equals("ANY")) {
+            // Show target for other challenge types
+            Bukkit.broadcastMessage(ChatColor.YELLOW + "Target: " + ChatColor.WHITE + formatItemName(activeChallenge.getTarget()));
+        }
+        
         Bukkit.broadcastMessage(ChatColor.YELLOW + "Duration: " + ChatColor.WHITE + activeChallenge.getDuration() + " seconds");
         Bukkit.broadcastMessage(ChatColor.YELLOW + "Type /challenge to view leaderboard");
         Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -584,6 +463,30 @@ public class ChallengeManager {
      */
     public FileConfiguration getChallengesConfig() {
         return challengesConfig;
+    }
+    
+    /**
+     * Format item/material name for display (IRON_SWORD -> Iron Sword)
+     */
+    private String formatItemName(String materialName) {
+        if (materialName == null || materialName.isEmpty()) {
+            return materialName;
+        }
+        
+        String[] parts = materialName.toLowerCase().split("_");
+        StringBuilder result = new StringBuilder();
+        for (String part : parts) {
+            if (result.length() > 0) {
+                result.append(" ");
+            }
+            if (part.length() > 0) {
+                result.append(Character.toUpperCase(part.charAt(0)));
+                if (part.length() > 1) {
+                    result.append(part.substring(1));
+                }
+            }
+        }
+        return result.toString();
     }
     
     /**

--- a/src/main/resources/challenges.yml
+++ b/src/main/resources/challenges.yml
@@ -1,0 +1,294 @@
+# QuestLogs Challenges Configuration
+# This file contains all timed server-wide challenges/mini-games
+
+# Challenge Settings
+settings:
+  # Enable/disable the challenge system
+  enabled: true
+  
+  # How often to start a new challenge (in seconds)
+  # Default: 3600 (1 hour)
+  frequency: 3600
+  
+  # Default duration for challenges (in seconds)
+  # Default: 300 (5 minutes)
+  duration: 300
+  
+  # How often to remind players about active challenge (in seconds)
+  # Default: 60 (1 minute)
+  announce-interval: 60
+  
+  # Broadcast when challenge starts
+  broadcast-start: true
+  
+  # Broadcast when challenge ends
+  broadcast-end: true
+  
+  # Number of top players to reward (1st, 2nd, 3rd, etc.)
+  reward-top-players: 3
+  
+  # Minimum players online to start a challenge
+  # Challenges won't start if fewer players are online
+  minimum-players: 2
+
+# Challenge Pool
+# All challenges that can be randomly selected
+# You can add, remove, or modify challenges here
+challenge-pool:
+  # Easy Challenges (common resources, modest rewards)
+  stone_sprint:
+    name: "Stone Mining Sprint"
+    description: "Mine the most stone!"
+    type: MINE_BLOCKS
+    target: STONE
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 16
+        COAL: 32
+      2nd:
+        IRON_INGOT: 8
+        COAL: 16
+      3rd:
+        IRON_INGOT: 4
+        COAL: 8
+  
+  wood_chopper:
+    name: "Lumberjack Challenge"
+    description: "Break the most logs!"
+    type: BREAK_BLOCKS
+    target: OAK_LOG
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 24
+        GOLDEN_APPLE: 8
+      2nd:
+        IRON_INGOT: 12
+        GOLDEN_APPLE: 4
+      3rd:
+        IRON_INGOT: 6
+        GOLDEN_APPLE: 2
+  
+  zombie_hunter:
+    name: "Zombie Hunt"
+    description: "Kill the most zombies!"
+    type: KILL_MOBS
+    target: ZOMBIE
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 12
+        GOLD_INGOT: 4
+      2nd:
+        IRON_INGOT: 6
+        GOLD_INGOT: 2
+      3rd:
+        IRON_INGOT: 3
+        GOLD_INGOT: 1
+  
+  # Medium Challenges (less common resources, better rewards)
+  coal_rush:
+    name: "Coal Rush"
+    description: "Mine the most coal ore!"
+    type: MINE_BLOCKS
+    target: COAL_ORE
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 20
+        DIAMOND: 2
+      2nd:
+        IRON_INGOT: 10
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 5
+  
+  skeleton_sniper:
+    name: "Skeleton Sniper"
+    description: "Kill the most skeletons!"
+    type: KILL_MOBS
+    target: SKELETON
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 16
+        DIAMOND: 2
+      2nd:
+        IRON_INGOT: 8
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 4
+  
+  iron_seeker:
+    name: "Iron Seeker"
+    description: "Mine the most iron ore!"
+    type: MINE_BLOCKS
+    target: IRON_ORE
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 24
+        DIAMOND: 3
+      2nd:
+        IRON_INGOT: 12
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 6
+  
+  # Hard Challenges (rare resources, premium rewards)
+  diamond_dash:
+    name: "Diamond Dash"
+    description: "Mine the most diamond ore!"
+    type: MINE_BLOCKS
+    target: DIAMOND_ORE
+    duration: 300
+    rewards:
+      1st:
+        DIAMOND: 5
+        IRON_INGOT: 16
+      2nd:
+        DIAMOND: 3
+        IRON_INGOT: 8
+      3rd:
+        DIAMOND: 1
+        IRON_INGOT: 4
+  
+  nether_explorer:
+    name: "Nether Explorer"
+    description: "Explore the most blocks in the Nether!"
+    type: EXPLORE_BLOCKS
+    target: ANY
+    duration: 300
+    rewards:
+      1st:
+        DIAMOND: 4
+        GOLD_INGOT: 8
+      2nd:
+        DIAMOND: 2
+        GOLD_INGOT: 4
+      3rd:
+        DIAMOND: 1
+        GOLD_INGOT: 2
+  
+  # Fun/Creative Challenges
+  builder_challenge:
+    name: "Speed Builder"
+    description: "Place the most blocks!"
+    type: PLACE_BLOCKS
+    target: COBBLESTONE
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 12
+        OAK_PLANKS: 64
+      2nd:
+        IRON_INGOT: 6
+        OAK_PLANKS: 32
+      3rd:
+        IRON_INGOT: 3
+        OAK_PLANKS: 16
+  
+  crafting_master:
+    name: "Crafting Master"
+    description: "Craft the most items!"
+    type: CRAFT_ITEMS
+    target: ANY
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 16
+        GOLD_INGOT: 8
+      2nd:
+        IRON_INGOT: 8
+        GOLD_INGOT: 4
+      3rd:
+        IRON_INGOT: 4
+        GOLD_INGOT: 2
+  
+  # Specific Crafting Challenges
+  tool_smith:
+    name: "Tool Smith Challenge"
+    description: "Craft the most tools!"
+    type: CRAFT_ITEMS
+    target: "IRON_PICKAXE,IRON_AXE,IRON_SHOVEL,IRON_HOE,IRON_SWORD"
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 8
+        DIAMOND: 2
+      2nd:
+        IRON_INGOT: 4
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 2
+  
+  armor_crafter:
+    name: "Armor Crafter Challenge"
+    description: "Craft the most armor pieces!"
+    type: CRAFT_ITEMS
+    target: "IRON_HELMET,IRON_CHESTPLATE,IRON_LEGGINGS,IRON_BOOTS"
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 12
+        DIAMOND: 1
+      2nd:
+        IRON_INGOT: 6
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 3
+  
+  weapon_forge:
+    name: "Weapon Forge Challenge"
+    description: "Craft the most weapons!"
+    type: CRAFT_ITEMS
+    target: "IRON_SWORD,IRON_AXE,BOW,CROSSBOW"
+    duration: 300
+    rewards:
+      1st:
+        IRON_INGOT: 8
+        DIAMOND: 2
+      2nd:
+        IRON_INGOT: 4
+        DIAMOND: 1
+      3rd:
+        IRON_INGOT: 2
+  
+  food_chef:
+    name: "Master Chef Challenge"
+    description: "Craft the most food items!"
+    type: CRAFT_ITEMS
+    target: "BREAD,CAKE,COOKIE,PUMPKIN_PIE"
+    duration: 300
+    rewards:
+      1st:
+        GOLDEN_APPLE: 16
+        BREAD: 32
+        COOKIE: 8
+      2nd:
+        GOLDEN_APPLE: 8
+        BREAD: 16
+        COOKIE: 4
+      3rd:
+        GOLDEN_APPLE: 4
+        BREAD: 8
+        COOKIE: 2
+  
+  redstone_engineer:
+    name: "Redstone Engineer"
+    description: "Craft the most redstone items!"
+    type: CRAFT_ITEMS
+    target: "REDSTONE_TORCH,REPEATER,COMPARATOR,PISTON,STICKY_PISTON"
+    duration: 300
+    rewards:
+      1st:
+        REDSTONE: 16
+        IRON_INGOT: 8
+      2nd:
+        REDSTONE: 8
+        IRON_INGOT: 4
+      3rd:
+        REDSTONE: 4
+        IRON_INGOT: 2
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: QuestLogs
-version: 1.0.2
+version: 1.0.3
 main: com.questlogs.QuestLogsPlugin
 api-version: 1.21
 description: Quest system for tracking player exploration and achievements


### PR DESCRIPTION
- Updated Spigot API to 1.21-R0.1-SNAPSHOT for Minecraft 1.21.11 compatibility
- Fixed crafting challenge tracking bug (event cancellation check, improved recipe handling)
- Enhanced crafting challenges with specific item targets (comma-separated support)
- Added 5 new specific crafting challenges (tools, armor, weapons, food, redstone)
- Removed all enchanted book rewards from challenges (they had no enchantments)
- Added editable challenges.yml config file with all default challenges
- Improved challenge announcements to show tracked items
- Fixed shift-click crafting amount calculation for better accuracy