### PR TITLE
Fix player quit lag spikes and add ASCII mode for challenges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.questlogs</groupId>
     <artifactId>QuestLogs</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <name>QuestLogs</name>

--- a/src/main/java/com/questlogs/commands/ChallengeCommand.java
+++ b/src/main/java/com/questlogs/commands/ChallengeCommand.java
@@ -29,11 +29,15 @@ public class ChallengeCommand implements CommandExecutor {
             return true;
         }
         
+        // Get ASCII mode setting
+        boolean asciiMode = plugin.getChallengeManager().isAsciiMode();
+        String border = asciiMode ? "===========================" : "━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+        
         // Display challenge info
         sender.sendMessage("");
-        sender.sendMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        sender.sendMessage(ChatColor.GOLD + border);
         sender.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "Active Challenge");
-        sender.sendMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        sender.sendMessage(ChatColor.GOLD + border);
         sender.sendMessage(ChatColor.AQUA + activeChallenge.getName());
         sender.sendMessage(ChatColor.GRAY + activeChallenge.getDescription());
         sender.sendMessage("");
@@ -49,7 +53,7 @@ public class ChallengeCommand implements CommandExecutor {
             sender.sendMessage(ChatColor.YELLOW + "Current Leaderboard:");
             for (int i = 0; i < Math.min(10, leaderboard.size()); i++) {
                 Map.Entry<String, Integer> entry = leaderboard.get(i);
-                String medal = getMedal(i + 1);
+                String medal = getMedal(i + 1, asciiMode);
                 ChatColor color = getPlaceColor(i + 1);
                 sender.sendMessage(color + "  " + medal + " " + entry.getKey() + 
                                  ChatColor.GRAY + " - " + ChatColor.YELLOW + entry.getValue());
@@ -82,18 +86,27 @@ public class ChallengeCommand implements CommandExecutor {
             }
         }
         
-        sender.sendMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        sender.sendMessage(ChatColor.GOLD + border);
         sender.sendMessage("");
         
         return true;
     }
     
-    private String getMedal(int place) {
-        switch (place) {
-            case 1: return "🥇";
-            case 2: return "🥈";
-            case 3: return "🥉";
-            default: return String.valueOf(place) + ".";
+    private String getMedal(int place, boolean asciiMode) {
+        if (asciiMode) {
+            switch (place) {
+                case 1: return "[1st]";
+                case 2: return "[2nd]";
+                case 3: return "[3rd]";
+                default: return "[" + place + "th]";
+            }
+        } else {
+            switch (place) {
+                case 1: return "🥇";
+                case 2: return "🥈";
+                case 3: return "🥉";
+                default: return String.valueOf(place) + ".";
+            }
         }
     }
     

--- a/src/main/java/com/questlogs/listeners/PlaytimeListener.java
+++ b/src/main/java/com/questlogs/listeners/PlaytimeListener.java
@@ -53,6 +53,8 @@ public class PlaytimeListener implements Listener {
             plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
                 plugin.getStatsManager().savePlayerStats(playerId);
             });
+        } else {
+            plugin.getLogger().warning("Player " + player.getName() + " quit but had no session start time tracked");
         }
     }
     

--- a/src/main/java/com/questlogs/listeners/PlaytimeListener.java
+++ b/src/main/java/com/questlogs/listeners/PlaytimeListener.java
@@ -49,8 +49,10 @@ public class PlaytimeListener implements Listener {
             // Add to player's total playtime
             plugin.getStatsManager().getPlayerStats(playerId).addPlaytime(sessionDuration);
             
-            // Save stats to database
-            plugin.getStatsManager().saveStats();
+            // Save stats for THIS PLAYER ONLY, asynchronously to prevent lag spikes
+            plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+                plugin.getStatsManager().savePlayerStats(playerId);
+            });
         }
     }
     

--- a/src/main/java/com/questlogs/managers/ChallengeManager.java
+++ b/src/main/java/com/questlogs/managers/ChallengeManager.java
@@ -33,6 +33,9 @@ public class ChallengeManager {
     private BukkitTask schedulerTask;
     private BukkitTask reminderTask;
     
+    // ASCII mode settings for compatibility
+    private boolean useAsciiCharacters;
+    
     public ChallengeManager(QuestLogsPlugin plugin) {
         this.plugin = plugin;
         this.logger = plugin.getLogger();
@@ -64,7 +67,11 @@ public class ChallengeManager {
             challengePool.addAll(poolSection.getKeys(false));
         }
         
-        logger.info("Loaded " + challengePool.size() + " challenges");
+        // Load ASCII mode setting
+        useAsciiCharacters = challengesConfig.getBoolean("settings.use-ascii-characters", false);
+        
+        logger.info("Loaded " + challengePool.size() + " challenges" + 
+                   (useAsciiCharacters ? " (ASCII mode enabled)" : ""));
     }
     
     /**
@@ -299,10 +306,13 @@ public class ChallengeManager {
      * Broadcast challenge start
      */
     private void broadcastChallengeStart() {
+        String border = getBorderLine();
+        String trophy = getTrophyPrefix();
+        
         Bukkit.broadcastMessage("");
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        Bukkit.broadcastMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "🏆 CHALLENGE STARTED! 🏆");
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
+        Bukkit.broadcastMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + trophy + " CHALLENGE STARTED! " + trophy);
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
         Bukkit.broadcastMessage(ChatColor.AQUA + activeChallenge.getName());
         Bukkit.broadcastMessage(ChatColor.GRAY + activeChallenge.getDescription());
         
@@ -331,7 +341,7 @@ public class ChallengeManager {
         
         Bukkit.broadcastMessage(ChatColor.YELLOW + "Duration: " + ChatColor.WHITE + activeChallenge.getDuration() + " seconds");
         Bukkit.broadcastMessage(ChatColor.YELLOW + "Type /challenge to view leaderboard");
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
         Bukkit.broadcastMessage("");
         
         // Play sound
@@ -345,7 +355,8 @@ public class ChallengeManager {
      */
     private void broadcastChallengeReminder() {
         long remaining = activeChallenge.getRemainingSeconds();
-        Bukkit.broadcastMessage(ChatColor.YELLOW + "⏰ Challenge: " + ChatColor.AQUA + activeChallenge.getName() + 
+        String clock = getClockPrefix();
+        Bukkit.broadcastMessage(ChatColor.YELLOW + clock + " Challenge: " + ChatColor.AQUA + activeChallenge.getName() + 
                                ChatColor.GRAY + " - " + ChatColor.WHITE + remaining + "s remaining");
     }
     
@@ -353,10 +364,13 @@ public class ChallengeManager {
      * Broadcast challenge end
      */
     private void broadcastChallengeEnd(List<Map.Entry<String, Integer>> leaderboard) {
+        String border = getBorderLine();
+        String trophy = getTrophyPrefix();
+        
         Bukkit.broadcastMessage("");
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        Bukkit.broadcastMessage(ChatColor.GREEN + "" + ChatColor.BOLD + "🏆 CHALLENGE COMPLETE! 🏆");
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
+        Bukkit.broadcastMessage(ChatColor.GREEN + "" + ChatColor.BOLD + trophy + " CHALLENGE COMPLETE! " + trophy);
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
         Bukkit.broadcastMessage(ChatColor.AQUA + activeChallenge.getName());
         Bukkit.broadcastMessage("");
         
@@ -373,7 +387,7 @@ public class ChallengeManager {
             }
         }
         
-        Bukkit.broadcastMessage(ChatColor.GOLD + "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Bukkit.broadcastMessage(ChatColor.GOLD + border);
         Bukkit.broadcastMessage("");
         
         // Play sound
@@ -383,12 +397,49 @@ public class ChallengeManager {
     }
     
     private String getMedal(int place) {
-        switch (place) {
-            case 1: return "🥇";
-            case 2: return "🥈";
-            case 3: return "🥉";
-            default: return String.valueOf(place) + ".";
+        if (useAsciiCharacters) {
+            switch (place) {
+                case 1: return "[1st]";
+                case 2: return "[2nd]";
+                case 3: return "[3rd]";
+                default: return "[" + place + "th]";
+            }
+        } else {
+            switch (place) {
+                case 1: return "🥇";
+                case 2: return "🥈";
+                case 3: return "🥉";
+                default: return String.valueOf(place) + ".";
+            }
         }
+    }
+    
+    /**
+     * Get border line for broadcasts (respects ASCII mode)
+     */
+    private String getBorderLine() {
+        return useAsciiCharacters ? "===================================" : "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+    }
+    
+    /**
+     * Get trophy/title prefix (respects ASCII mode)
+     */
+    private String getTrophyPrefix() {
+        return useAsciiCharacters ? "***" : "🏆";
+    }
+    
+    /**
+     * Get clock/timer prefix (respects ASCII mode)
+     */
+    private String getClockPrefix() {
+        return useAsciiCharacters ? "[!]" : "⏰";
+    }
+    
+    /**
+     * Check if ASCII mode is enabled
+     */
+    public boolean isAsciiMode() {
+        return useAsciiCharacters;
     }
     
     /**

--- a/src/main/java/com/questlogs/managers/StatsManager.java
+++ b/src/main/java/com/questlogs/managers/StatsManager.java
@@ -85,6 +85,9 @@ public class StatsManager {
         PlayerStats stats = playerStats.get(playerId);
         if (stats != null) {
             database.savePlayerStats(stats);
+            logger.info("Saved stats for player " + playerId + " to database");
+        } else {
+            logger.warning("Could not save stats for player " + playerId + " - not found in cache");
         }
     }
     

--- a/src/main/java/com/questlogs/managers/StatsManager.java
+++ b/src/main/java/com/questlogs/managers/StatsManager.java
@@ -78,6 +78,17 @@ public class StatsManager {
     }
     
     /**
+     * Save stats for a specific player only
+     * This is more efficient than saveStats() when only one player's data changed
+     */
+    public void savePlayerStats(UUID playerId) {
+        PlayerStats stats = playerStats.get(playerId);
+        if (stats != null) {
+            database.savePlayerStats(stats);
+        }
+    }
+    
+    /**
      * Clear stats for a specific player
      */
     public void clearPlayerStats(UUID playerId) {

--- a/src/main/resources/challenges.yml
+++ b/src/main/resources/challenges.yml
@@ -30,6 +30,12 @@ settings:
   # Minimum players online to start a challenge
   # Challenges won't start if fewer players are online
   minimum-players: 2
+  
+  # Use ASCII-only characters in broadcasts
+  # Enable this if players have trouble seeing Unicode characters (emojis, box-drawing)
+  # When true: Uses [1st], [2nd], [3rd] and === instead of medals and fancy borders
+  # When false: Uses emojis and Unicode box-drawing characters
+  use-ascii-characters: false
 
 # Challenge Pool
 # All challenges that can be randomly selected

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: QuestLogs
-version: 1.0.3
+version: 1.0.4
 main: com.questlogs.QuestLogsPlugin
 api-version: 1.21
 description: Quest system for tracking player exploration and achievements


### PR DESCRIPTION
## Summary

- **Fix critical performance issue**: Player quit was saving ALL players' stats synchronously on the main thread, causing 10+ second server freezes. Now saves only the quitting player's stats, asynchronously.
- **Add ASCII mode for challenge broadcasts**: New `use-ascii-characters` config option for servers where players can't see Unicode emojis/box-drawing characters.
- **Bump version to 1.0.4**

## Changes

- `PlaytimeListener`: Save stats asynchronously for only the quitting player
- `StatsManager`: Add `savePlayerStats(UUID)` method for single-player saves
- `ChallengeManager`: Add ASCII mode support with helper methods
- `ChallengeCommand`: Respect ASCII mode setting
- `challenges.yml`: Add `use-ascii-characters` config option

## Test plan

- [x] Test player join/leave no longer causes lag spikes
- [x] Test `use-ascii-characters: false` shows Unicode emojis and borders
- [x] Test `use-ascii-characters: true` shows ASCII `[1st]`, `[2nd]`, `===` etc.
- [x] Test `/challengeadmin reload` picks up ASCII mode changes
